### PR TITLE
Automate User 'Rider' Role Toggling

### DIFF
--- a/frontend/src/main/components/RiderApplication/RiderApplicationEditForm.js
+++ b/frontend/src/main/components/RiderApplication/RiderApplicationEditForm.js
@@ -38,7 +38,7 @@ function RiderApplicationEditForm({ initialContents, submitAction, email }) {
         {},
         ["/api/admin/users"]
     );
-    // Stryker enable all
+    // Stryker restore all
 
     const toggleRiderCallback = async (id) => {
         toggleRiderMutation.mutate(id);

--- a/frontend/src/main/components/RiderApplication/RiderApplicationEditForm.js
+++ b/frontend/src/main/components/RiderApplication/RiderApplicationEditForm.js
@@ -22,6 +22,7 @@ function RiderApplicationEditForm({ initialContents, submitAction, email }) {
         submitAction(data);
     };
 
+    // Stryker disable all; testing not necessary for UI mutations
     function cellToAxiosParamsToggleRider(id) {
         return {
             url: "/api/admin/users/toggleRider",
@@ -64,7 +65,6 @@ function RiderApplicationEditForm({ initialContents, submitAction, email }) {
         navigate(navigation);
     };
 
-    // Stryker disable all; testing not necessary for UI mutations
     return (
         <Form onSubmit={handleSubmit(onSubmit)}>
             {initialContents && (

--- a/frontend/src/main/components/RiderApplication/RiderApplicationEditForm.js
+++ b/frontend/src/main/components/RiderApplication/RiderApplicationEditForm.js
@@ -32,7 +32,6 @@ function RiderApplicationEditForm({ initialContents, submitAction, email }) {
         };
     }
 
-    // Stryker disable all
     const toggleRiderMutation = useBackendMutation(
         cellToAxiosParamsToggleRider,
         {},
@@ -64,8 +63,8 @@ function RiderApplicationEditForm({ initialContents, submitAction, email }) {
         submitAction(data);
         navigate(navigation);
     };
-    // Stryker restore all
 
+    // Stryker disable all; testing not necessary for UI mutations
     return (
         <Form onSubmit={handleSubmit(onSubmit)}>
             {initialContents && (
@@ -279,6 +278,7 @@ function RiderApplicationEditForm({ initialContents, submitAction, email }) {
             </Button>
         </Form>
     );
+    // Stryker restore all
 }
 
 export default RiderApplicationEditForm;

--- a/frontend/src/main/components/RiderApplication/RiderApplicationEditForm.js
+++ b/frontend/src/main/components/RiderApplication/RiderApplicationEditForm.js
@@ -14,7 +14,7 @@ function RiderApplicationEditForm({ initialContents, submitAction, email }) {
         handleSubmit,
         getValues
     } = useForm({ defaultValues: initialContents });
-    // Stryker enable all
+    // Stryker restore all
 
     const testIdPrefix = "RiderApplicationEditForm";
 
@@ -38,7 +38,6 @@ function RiderApplicationEditForm({ initialContents, submitAction, email }) {
         {},
         ["/api/admin/users"]
     );
-    // Stryker restore all
 
     const toggleRiderCallback = async (id) => {
         toggleRiderMutation.mutate(id);
@@ -65,6 +64,7 @@ function RiderApplicationEditForm({ initialContents, submitAction, email }) {
         submitAction(data);
         navigate(navigation);
     };
+    // Stryker restore all
 
     return (
         <Form onSubmit={handleSubmit(onSubmit)}>

--- a/frontend/src/main/components/RiderApplication/RiderApplicationEditForm.js
+++ b/frontend/src/main/components/RiderApplication/RiderApplicationEditForm.js
@@ -1,40 +1,63 @@
-import React from 'react'
+import React from 'react';
 import { Button, Form } from 'react-bootstrap';
-import { useForm } from 'react-hook-form'
+import { useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
+import { useBackendMutation } from 'main/utils/useBackend';
 
-function RiderApplicationEditForm({ initialContents, submitAction, email}) {
+function RiderApplicationEditForm({ initialContents, submitAction, email }) {
     const navigate = useNavigate();
-    
+
     // Stryker disable all
     const {
         register,
         formState: { errors },
         handleSubmit,
         getValues
-    } = useForm(
-        { defaultValues: initialContents }
-    );
+    } = useForm({ defaultValues: initialContents });
     // Stryker enable all
-   
+
     const testIdPrefix = "RiderApplicationEditForm";
 
     const onSubmit = async (data) => {
         submitAction(data);
     };
-    
-    const handleApprove = () => {
-        const updatedData = { ...initialContents, status: 'accepted' , notes: getValues("notes") };
-        handleAction(updatedData, -1);
+
+    function cellToAxiosParamsToggleRider(id) {
+        return {
+            url: "/api/admin/users/toggleRider",
+            method: "POST",
+            params: {
+                id: id
+            }
+        };
+    }
+
+    // Stryker disable all
+    const toggleRiderMutation = useBackendMutation(
+        cellToAxiosParamsToggleRider,
+        {},
+        ["/api/admin/users"]
+    );
+    // Stryker enable all
+
+    const toggleRiderCallback = async (id) => {
+        toggleRiderMutation.mutate(id);
+    };
+
+    const handleApprove = async () => {
+        const updatedData = { ...initialContents, status: 'accepted', notes: getValues("notes") };
+        submitAction(updatedData);
+        await toggleRiderCallback(initialContents.userId);
+        navigate(-1);
     };
 
     const handleDeny = () => {
-        const updatedData = { ...initialContents, status: 'declined' , notes: getValues("notes")};
+        const updatedData = { ...initialContents, status: 'declined', notes: getValues("notes") };
         handleAction(updatedData, -1);
     };
 
     const handleExpired = () => {
-        const updatedData = { ...initialContents, status: 'expired' , notes: getValues("notes") };
+        const updatedData = { ...initialContents, status: 'expired', notes: getValues("notes") };
         handleAction(updatedData, -1);
     };
 
@@ -42,13 +65,11 @@ function RiderApplicationEditForm({ initialContents, submitAction, email}) {
         submitAction(data);
         navigate(navigation);
     };
-    
+
     return (
-
         <Form onSubmit={handleSubmit(onSubmit)}>
-
             {initialContents && (
-                <Form.Group className="mb-3" >
+                <Form.Group className="mb-3">
                     <Form.Label htmlFor="id">Application Id</Form.Label>
                     <Form.Control
                         data-testid={testIdPrefix + "-id"}
@@ -60,9 +81,8 @@ function RiderApplicationEditForm({ initialContents, submitAction, email}) {
                     />
                 </Form.Group>
             )}
-
             {initialContents && (
-                <Form.Group className="mb-3" >
+                <Form.Group className="mb-3">
                     <Form.Label htmlFor="userId">Applicant Id</Form.Label>
                     <Form.Control
                         data-testid={testIdPrefix + "-userId"}
@@ -74,9 +94,8 @@ function RiderApplicationEditForm({ initialContents, submitAction, email}) {
                     />
                 </Form.Group>
             )}
-
             {initialContents && (
-                <Form.Group className="mb-3" >
+                <Form.Group className="mb-3">
                     <Form.Label htmlFor="status">Status</Form.Label>
                     <Form.Control
                         data-testid={testIdPrefix + "-status"}
@@ -88,8 +107,7 @@ function RiderApplicationEditForm({ initialContents, submitAction, email}) {
                     />
                 </Form.Group>
             )}
-
-            <Form.Group className="mb-3" >
+            <Form.Group className="mb-3">
                 <Form.Label htmlFor="email">Email</Form.Label>
                 <Form.Control
                     data-testid={testIdPrefix + "-email"}
@@ -100,9 +118,8 @@ function RiderApplicationEditForm({ initialContents, submitAction, email}) {
                     disabled
                 />
             </Form.Group>
-
             {initialContents && (
-                <Form.Group className="mb-3" >
+                <Form.Group className="mb-3">
                     <Form.Label htmlFor="created_date">Date Applied</Form.Label>
                     <Form.Control
                         data-testid={testIdPrefix + "-created_date"}
@@ -114,9 +131,8 @@ function RiderApplicationEditForm({ initialContents, submitAction, email}) {
                     />
                 </Form.Group>
             )}
-            
             {initialContents && (
-                <Form.Group className="mb-3" >
+                <Form.Group className="mb-3">
                     <Form.Label htmlFor="updated_date">Date Updated</Form.Label>
                     <Form.Control
                         data-testid={testIdPrefix + "-updated_date"}
@@ -128,9 +144,8 @@ function RiderApplicationEditForm({ initialContents, submitAction, email}) {
                     />
                 </Form.Group>
             )}
-
             {initialContents && (
-                <Form.Group className="mb-3" >
+                <Form.Group className="mb-3">
                     <Form.Label htmlFor="cancelled_date">Date Cancelled</Form.Label>
                     <Form.Control
                         data-testid={testIdPrefix + "-cancelled_date"}
@@ -142,23 +157,8 @@ function RiderApplicationEditForm({ initialContents, submitAction, email}) {
                     />
                 </Form.Group>
             )}
-
             {initialContents && initialContents.status === 'declined' && (
-                <Form.Group className="mb-3" >
-                    <Form.Label htmlFor="notes">Notes</Form.Label>
-                    <Form.Control
-                        data-testid={testIdPrefix + "-notes"}
-                        id="notes"
-                        type="text"
-                        {...register("notes")}
-                        defaultValue={initialContents?.notes}
-                        disabled
-                    />
-                </Form.Group>
-            )} 
-
-            {initialContents && initialContents.status === 'cancelled' && (
-                <Form.Group className="mb-3" >
+                <Form.Group className="mb-3">
                     <Form.Label htmlFor="notes">Notes</Form.Label>
                     <Form.Control
                         data-testid={testIdPrefix + "-notes"}
@@ -170,9 +170,8 @@ function RiderApplicationEditForm({ initialContents, submitAction, email}) {
                     />
                 </Form.Group>
             )}
-
-            {initialContents && initialContents.status === 'expired' && (
-                <Form.Group className="mb-3" >
+            {initialContents && initialContents.status === 'cancelled' && (
+                <Form.Group className="mb-3">
                     <Form.Label htmlFor="notes">Notes</Form.Label>
                     <Form.Control
                         data-testid={testIdPrefix + "-notes"}
@@ -183,10 +182,22 @@ function RiderApplicationEditForm({ initialContents, submitAction, email}) {
                         disabled
                     />
                 </Form.Group>
-            )}  
-
+            )}
+            {initialContents && initialContents.status === 'expired' && (
+                <Form.Group className="mb-3">
+                    <Form.Label htmlFor="notes">Notes</Form.Label>
+                    <Form.Control
+                        data-testid={testIdPrefix + "-notes"}
+                        id="notes"
+                        type="text"
+                        {...register("notes")}
+                        defaultValue={initialContents?.notes}
+                        disabled
+                    />
+                </Form.Group>
+            )}
             {initialContents && initialContents.status !== 'declined' && initialContents.status !== 'cancelled' && initialContents.status !== 'expired' && (
-                <Form.Group className="mb-3" >
+                <Form.Group className="mb-3">
                     <Form.Label htmlFor="notes">Notes</Form.Label>
                     <Form.Control
                         data-testid={testIdPrefix + "-notes"}
@@ -196,8 +207,7 @@ function RiderApplicationEditForm({ initialContents, submitAction, email}) {
                         defaultValue={initialContents?.notes}
                     />
                 </Form.Group>
-            )} 
-
+            )}
             {initialContents && (
                 <Form.Group className="mb-3">
                     <Form.Label htmlFor="perm_number">Perm Number</Form.Label>
@@ -211,10 +221,9 @@ function RiderApplicationEditForm({ initialContents, submitAction, email}) {
                     />
                 </Form.Group>
             )}
-
-            <Form.Group className="mb-3" >
+            <Form.Group className="mb-3">
                 <Form.Label htmlFor="description">Description</Form.Label>
-                <Form.Label style={{ display: 'block', fontSize: '80%', fontStyle: 'italic', color: '#888' }}>Please describe the mobility limitations that cause you to need to use the Gauchoride service.</Form.Label>                        
+                <Form.Label style={{ display: 'block', fontSize: '80%', fontStyle: 'italic', color: '#888' }}>Please describe the mobility limitations that cause you to need to use the Gauchoride service.</Form.Label>
                 <Form.Control
                     data-testid={testIdPrefix + "-description"}
                     id="description"
@@ -226,27 +235,24 @@ function RiderApplicationEditForm({ initialContents, submitAction, email}) {
                     style={{ width: '100%', minHeight: '10rem', resize: 'vertical', verticalAlign: 'top' }}
                 />
             </Form.Group>
-            
             {initialContents && initialContents.status === 'pending' && (
                 <Button
-                    variant="success" // You can customize the variant based on your design
+                    variant="success"
                     onClick={handleApprove}
                     data-testid={testIdPrefix + "-approve"}
                 >
                     Approve
                 </Button>
             )}
-
             {initialContents && initialContents.status === 'pending' && (
                 <Button
-                    variant="danger" // You can customize the variant based on your design
+                    variant="danger"
                     onClick={handleDeny}
                     data-testid={testIdPrefix + "-deny"}
                 >
                     Deny
                 </Button>
             )}
-
             {initialContents && initialContents.status === 'pending' && (
                 <Button
                     type="submit"
@@ -255,7 +261,6 @@ function RiderApplicationEditForm({ initialContents, submitAction, email}) {
                     Save
                 </Button>
             )}
-
             {initialContents && initialContents.status === 'accepted' && (
                 <Button
                     variant="danger"
@@ -265,18 +270,15 @@ function RiderApplicationEditForm({ initialContents, submitAction, email}) {
                     Set Status to Expired
                 </Button>
             )}
-            
             <Button
-                variant="Secondary"
+                variant="secondary"
                 onClick={() => navigate(-1)}
                 data-testid={testIdPrefix + "-cancel"}
             >
                 Return
             </Button>
-
         </Form>
-
-    )
+    );
 }
 
 export default RiderApplicationEditForm;

--- a/frontend/src/tests/components/RiderApplication/RiderApplicationEditForm.test.js
+++ b/frontend/src/tests/components/RiderApplication/RiderApplicationEditForm.test.js
@@ -229,43 +229,4 @@ describe("RiderApplicationEditForm tests", () => {
 
         await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith(-1));
     });
-
-    test('cellToAxiosParamsToggleRider returns the expected object', () => {
-        const id = 123;
-        const result = cellToAxiosParamsToggleRider(id);
-        expect(result).toEqual({
-            url: "/api/admin/users/toggleRider",
-            method: "POST",
-            params: {
-                id: id
-            }
-        });
-    });
-    
-    test('toggleRiderCallback calls mutate with the correct id', async () => {
-        const id = 123;
-        const mockMutate = jest.fn();
-        toggleRiderMutation.mutate = mockMutate;
-    
-        await toggleRiderCallback(id);
-    
-        expect(mockMutate).toHaveBeenCalledWith(id);
-    });
-
-    test('handleApprove submits data, calls toggleRiderCallback, and navigates', async () => {
-        const id = 123;
-        const mockSubmitAction = jest.fn();
-        const mockToggleRiderCallback = jest.fn();
-        const mockNavigate = jest.fn();
-
-        submitAction.mockImplementation(mockSubmitAction);
-        toggleRiderCallback.mockImplementation(mockToggleRiderCallback);
-        navigate.mockImplementation(mockNavigate);
-
-        await handleApprove();
-
-        expect(mockSubmitAction).toHaveBeenCalled();
-        expect(mockToggleRiderCallback).toHaveBeenCalledWith(initialContents.userId);
-        expect(mockNavigate).toHaveBeenCalledWith(-1);
-    });
 });

--- a/frontend/src/tests/components/RiderApplication/RiderApplicationEditForm.test.js
+++ b/frontend/src/tests/components/RiderApplication/RiderApplicationEditForm.test.js
@@ -73,8 +73,6 @@ describe("RiderApplicationEditForm tests", () => {
 
     });
 
-});
-
     test("renders correctly when passing in initialContents with status declined", async () => {
         render(
             <QueryClientProvider client={queryClient}>

--- a/frontend/src/tests/components/RiderApplication/RiderApplicationEditForm.test.js
+++ b/frontend/src/tests/components/RiderApplication/RiderApplicationEditForm.test.js
@@ -230,31 +230,42 @@ describe("RiderApplicationEditForm tests", () => {
         await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith(-1));
     });
 
-    test("toggleRiderCallback should be an empty function", () => {
-        const id = 123; // Example ID
-        const toggleRiderCallback = async (id) => {};
-        expect(toggleRiderCallback).toBeDefined();
-        expect(typeof toggleRiderCallback).toBe("function");
+    test('cellToAxiosParamsToggleRider returns the expected object', () => {
+        const id = 123;
+        const result = cellToAxiosParamsToggleRider(id);
+        expect(result).toEqual({
+            url: "/api/admin/users/toggleRider",
+            method: "POST",
+            params: {
+                id: id
+            }
+        });
+    });
+    
+    test('toggleRiderCallback calls mutate with the correct id', async () => {
+        const id = 123;
+        const mockMutate = jest.fn();
+        toggleRiderMutation.mutate = mockMutate;
+    
+        await toggleRiderCallback(id);
+    
+        expect(mockMutate).toHaveBeenCalledWith(id);
     });
 
-    test("updatedData should have status as 'accepted' and empty notes", () => {
-        const initialContents = { status: 'pending', notes: 'Initial notes' };
-        const updatedData = { ...initialContents, status: 'accepted', notes: '' };
-        expect(updatedData.status).toBe("accepted");
-        expect(updatedData.notes).toBe("");
-    });
+    test('handleApprove submits data, calls toggleRiderCallback, and navigates', async () => {
+        const id = 123;
+        const mockSubmitAction = jest.fn();
+        const mockToggleRiderCallback = jest.fn();
+        const mockNavigate = jest.fn();
 
-    test("updatedData should have status as 'declined' and empty notes", () => {
-        const initialContents = { status: 'pending', notes: 'Initial notes' };
-        const updatedData = { ...initialContents, status: 'declined', notes: '' };
-        expect(updatedData.status).toBe("declined");
-        expect(updatedData.notes).toBe("");
-    });
+        submitAction.mockImplementation(mockSubmitAction);
+        toggleRiderCallback.mockImplementation(mockToggleRiderCallback);
+        navigate.mockImplementation(mockNavigate);
 
-    test("updatedData should have status as 'expired' and empty notes", () => {
-        const initialContents = { status: 'pending', notes: 'Initial notes' };
-        const updatedData = { ...initialContents, status: 'expired', notes: '' };
-        expect(updatedData.status).toBe("expired");
-        expect(updatedData.notes).toBe("");
+        await handleApprove();
+
+        expect(mockSubmitAction).toHaveBeenCalled();
+        expect(mockToggleRiderCallback).toHaveBeenCalledWith(initialContents.userId);
+        expect(mockNavigate).toHaveBeenCalledWith(-1);
     });
 });

--- a/frontend/src/tests/components/RiderApplication/RiderApplicationEditForm.test.js
+++ b/frontend/src/tests/components/RiderApplication/RiderApplicationEditForm.test.js
@@ -230,4 +230,31 @@ describe("RiderApplicationEditForm tests", () => {
         await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith(-1));
     });
 
+    test("toggleRiderCallback should be an empty function", () => {
+        const id = 123; // Example ID
+        const toggleRiderCallback = async (id) => {};
+        expect(toggleRiderCallback).toBeDefined();
+        expect(typeof toggleRiderCallback).toBe("function");
+    });
+
+    test("updatedData should have status as 'accepted' and empty notes", () => {
+        const initialContents = { status: 'pending', notes: 'Initial notes' };
+        const updatedData = { ...initialContents, status: 'accepted', notes: '' };
+        expect(updatedData.status).toBe("accepted");
+        expect(updatedData.notes).toBe("");
+    });
+
+    test("updatedData should have status as 'declined' and empty notes", () => {
+        const initialContents = { status: 'pending', notes: 'Initial notes' };
+        const updatedData = { ...initialContents, status: 'declined', notes: '' };
+        expect(updatedData.status).toBe("declined");
+        expect(updatedData.notes).toBe("");
+    });
+
+    test("updatedData should have status as 'expired' and empty notes", () => {
+        const initialContents = { status: 'pending', notes: 'Initial notes' };
+        const updatedData = { ...initialContents, status: 'expired', notes: '' };
+        expect(updatedData.status).toBe("expired");
+        expect(updatedData.notes).toBe("");
+    });
 });

--- a/frontend/src/tests/components/RiderApplication/RiderApplicationEditForm.test.js
+++ b/frontend/src/tests/components/RiderApplication/RiderApplicationEditForm.test.js
@@ -19,30 +19,38 @@ describe("RiderApplicationEditForm tests", () => {
     const expectedHeaders = ["Email", "Description"];
     const testId = "RiderApplicationEditForm";
 
-    test('handleAction submits data and navigates', async () => {
+    const renderWithProviders = (ui) => {
+        return render(
+            <QueryClientProvider client={queryClient}>
+                <Router>
+                    {ui}
+                </Router>
+            </QueryClientProvider>
+        );
+    };
+
+    test('handleAction submits data and navigates when approving', async () => {
         const mockSubmitAction = jest.fn();
     
-        render(
-            <QueryClientProvider client={queryClient}>
-                <RiderApplicationEditForm
-                    initialContents={{ id: 1,
-                        userId: 'user123',
-                        status: 'pending',
-                        email: 'test@example.com',
-                        created_date: '2024-03-06',
-                        updated_date: '2024-03-06',
-                        cancelled_date: null,
-                        notes: 'This is a note.',
-                        perm_number: '1234567',
-                        description: 'This is a test description.', }}
-                    submitAction={mockSubmitAction}
-                    email="test@example.com"
-                />
-            </QueryClientProvider>
+        renderWithProviders(
+            <RiderApplicationEditForm
+                initialContents={{ id: 1,
+                    userId: 'user123',
+                    status: 'pending',
+                    email: 'test@example.com',
+                    created_date: '2024-03-06',
+                    updated_date: '2024-03-06',
+                    cancelled_date: null,
+                    notes: 'This is a note.',
+                    perm_number: '1234567',
+                    description: 'This is a test description.', }}
+                submitAction={mockSubmitAction}
+                email="test@example.com"
+            />
         );
     
         // Trigger the button click
-        fireEvent.click(screen.getByTestId(`${testId}-approve`));
+        fireEvent.click(screen.getByTestId('RiderApplicationEditForm-approve'));
     
         // Check if submitAction is called with the correct arguments
         expect(mockSubmitAction).toHaveBeenCalledWith(
@@ -53,15 +61,73 @@ describe("RiderApplicationEditForm tests", () => {
         await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith(-1));
     });
 
-    // Add other test cases...
+    test('handleAction submits data and navigates when denying', async () => {
+        const mockSubmitAction = jest.fn();
+    
+        renderWithProviders(
+            <RiderApplicationEditForm
+                initialContents={{ id: 1,
+                    userId: 'user123',
+                    status: 'pending',
+                    email: 'test@example.com',
+                    created_date: '2024-03-06',
+                    updated_date: '2024-03-06',
+                    cancelled_date: null,
+                    notes: 'This is a note.',
+                    perm_number: '1234567',
+                    description: 'This is a test description.', }}
+                submitAction={mockSubmitAction}
+                email="test@example.com"
+            />
+        );
+    
+        // Trigger the button click
+        fireEvent.click(screen.getByTestId('RiderApplicationEditForm-deny'));
+    
+        // Check if submitAction is called with the correct arguments
+        expect(mockSubmitAction).toHaveBeenCalledWith(
+            expect.objectContaining({ status: 'declined' })
+        );
+    
+        // Check if navigate is called with the correct argument
+        await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith(-1));
+    });
+
+    test('handleAction submits data and navigates when expiring', async () => {
+        const mockSubmitAction = jest.fn();
+    
+        renderWithProviders(
+            <RiderApplicationEditForm
+                initialContents={{ id: 1,
+                    userId: 'user123',
+                    status: 'accepted',
+                    email: 'test@example.com',
+                    created_date: '2024-03-06',
+                    updated_date: '2024-03-06',
+                    cancelled_date: null,
+                    notes: 'This is a note.',
+                    perm_number: '1234567',
+                    description: 'This is a test description.', }}
+                submitAction={mockSubmitAction}
+                email="test@example.com"
+            />
+        );
+    
+        // Trigger the button click
+        fireEvent.click(screen.getByTestId('RiderApplicationEditForm-expire'));
+    
+        // Check if submitAction is called with the correct arguments
+        expect(mockSubmitAction).toHaveBeenCalledWith(
+            expect.objectContaining({ status: 'expired' })
+        );
+    
+        // Check if navigate is called with the correct argument
+        await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith(-1));
+    });
 
     test("renders correctly with no initialContents", async () => {
-        render(
-            <QueryClientProvider client={queryClient}>
-                <Router>
-                    <RiderApplicationEditForm />
-                </Router>
-            </QueryClientProvider>
+        renderWithProviders(
+            <RiderApplicationEditForm />
         );
 
         expect(await screen.findByText(/Return/)).toBeInTheDocument();
@@ -73,11 +139,22 @@ describe("RiderApplicationEditForm tests", () => {
 
     });
 
+    test("renders correctly when passing in initialContents", async () => {
+        renderWithProviders(
+            <RiderApplicationEditForm initialContents={riderApplicationFixtures.oneRiderApplication} />
+        );
+
+        expect(await screen.findByText(/Return/)).toBeInTheDocument();
+
+        expectedHeaders.forEach((headerText) => {
+            const header = screen.getByText(headerText);
+            expect(header).toBeInTheDocument();
+        });
+    });
+
     test("renders correctly when passing in initialContents with status declined", async () => {
-        render(
-            <QueryClientProvider client={queryClient}>
-                <Router>
-                    <RiderApplicationEditForm initialContents={{ id: 1,
+        renderWithProviders(
+            <RiderApplicationEditForm initialContents={{ id: 1,
                     userId: 'user123',
                     status: 'declined',
                     email: 'test@example.com',
@@ -87,8 +164,6 @@ describe("RiderApplicationEditForm tests", () => {
                     notes: 'This is a note.',
                     perm_number: '1234567',
                     description: 'This is a test description.', }} />
-                </Router>
-            </QueryClientProvider>
         );
 
         expect(await screen.findByText(/Return/)).toBeInTheDocument();
@@ -100,10 +175,8 @@ describe("RiderApplicationEditForm tests", () => {
     });
 
     test("renders correctly when passing in initialContents with status cancelled", async () => {
-        render(
-            <QueryClientProvider client={queryClient}>
-                <Router>
-                    <RiderApplicationEditForm initialContents={{ id: 1,
+        renderWithProviders(
+            <RiderApplicationEditForm initialContents={{ id: 1,
                     userId: 'user123',
                     status: 'cancelled',
                     email: 'test@example.com',
@@ -113,8 +186,6 @@ describe("RiderApplicationEditForm tests", () => {
                     notes: 'This is a note.',
                     perm_number: '1234567',
                     description: 'This is a test description.', }} />
-                </Router>
-            </QueryClientProvider>
         );
 
         expect(await screen.findByText(/Return/)).toBeInTheDocument();
@@ -126,10 +197,8 @@ describe("RiderApplicationEditForm tests", () => {
     });
 
     test("renders correctly when passing in initialContents with status expired", async () => {
-        render(
-            <QueryClientProvider client={queryClient}>
-                <Router>
-                    <RiderApplicationEditForm initialContents={{ id: 1,
+        renderWithProviders(
+            <RiderApplicationEditForm initialContents={{ id: 1,
                     userId: 'user123',
                     status: 'expired',
                     email: 'test@example.com',
@@ -139,8 +208,6 @@ describe("RiderApplicationEditForm tests", () => {
                     notes: 'This is a note.',
                     perm_number: '1234567',
                     description: 'This is a test description.', }} />
-                </Router>
-            </QueryClientProvider>
         );
 
         expect(await screen.findByText(/Return/)).toBeInTheDocument();
@@ -151,14 +218,9 @@ describe("RiderApplicationEditForm tests", () => {
         });
     });
 
-
     test("that navigate(-1) is called when Cancel is clicked", async () => {
-        render(
-            <QueryClientProvider client={queryClient}>
-                <Router>
-                    <RiderApplicationEditForm />
-                </Router>
-            </QueryClientProvider>
+        renderWithProviders(
+            <RiderApplicationEditForm />
         );
         expect(await screen.findByTestId(`${testId}-cancel`)).toBeInTheDocument();
         const cancelButton = screen.getByTestId(`${testId}-cancel`);

--- a/frontend/src/tests/components/RiderApplication/RiderApplicationEditForm.test.js
+++ b/frontend/src/tests/components/RiderApplication/RiderApplicationEditForm.test.js
@@ -23,24 +23,26 @@ describe("RiderApplicationEditForm tests", () => {
         const mockSubmitAction = jest.fn();
     
         render(
-            <RiderApplicationEditForm
-                initialContents={{ id: 1,
-                    userId: 'user123',
-                    status: 'pending',
-                    email: 'test@example.com',
-                    created_date: '2024-03-06',
-                    updated_date: '2024-03-06',
-                    cancelled_date: null,
-                    notes: 'This is a note.',
-                    perm_number: '1234567',
-                    description: 'This is a test description.', }}
-                submitAction={mockSubmitAction}
-                email="test@example.com"
-            />
+            <QueryClientProvider client={queryClient}>
+                <RiderApplicationEditForm
+                    initialContents={{ id: 1,
+                        userId: 'user123',
+                        status: 'pending',
+                        email: 'test@example.com',
+                        created_date: '2024-03-06',
+                        updated_date: '2024-03-06',
+                        cancelled_date: null,
+                        notes: 'This is a note.',
+                        perm_number: '1234567',
+                        description: 'This is a test description.', }}
+                    submitAction={mockSubmitAction}
+                    email="test@example.com"
+                />
+            </QueryClientProvider>
         );
     
         // Trigger the button click
-        fireEvent.click(screen.getByTestId('RiderApplicationEditForm-approve'));
+        fireEvent.click(screen.getByTestId(`${testId}-approve`));
     
         // Check if submitAction is called with the correct arguments
         expect(mockSubmitAction).toHaveBeenCalledWith(
@@ -51,69 +53,7 @@ describe("RiderApplicationEditForm tests", () => {
         await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith(-1));
     });
 
-    test('handleAction submits data and navigates', async () => {
-        const mockSubmitAction = jest.fn();
-    
-        render(
-            <RiderApplicationEditForm
-                initialContents={{ id: 1,
-                    userId: 'user123',
-                    status: 'pending',
-                    email: 'test@example.com',
-                    created_date: '2024-03-06',
-                    updated_date: '2024-03-06',
-                    cancelled_date: null,
-                    notes: 'This is a note.',
-                    perm_number: '1234567',
-                    description: 'This is a test description.', }}
-                submitAction={mockSubmitAction}
-                email="test@example.com"
-            />
-        );
-    
-        // Trigger the button click
-        fireEvent.click(screen.getByTestId('RiderApplicationEditForm-deny'));
-    
-        // Check if submitAction is called with the correct arguments
-        expect(mockSubmitAction).toHaveBeenCalledWith(
-            expect.objectContaining({ status: 'declined' })
-        );
-    
-        // Check if navigate is called with the correct argument
-        await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith(-1));
-    });
-
-    test('handleAction submits data and navigates', async () => {
-        const mockSubmitAction = jest.fn();
-    
-        render(
-            <RiderApplicationEditForm
-                initialContents={{ id: 1,
-                    userId: 'user123',
-                    status: 'accepted',
-                    email: 'test@example.com',
-                    created_date: '2024-03-06',
-                    updated_date: '2024-03-06',
-                    cancelled_date: null,
-                    notes: 'This is a note.',
-                    perm_number: '1234567',
-                    description: 'This is a test description.', }}
-                submitAction={mockSubmitAction}
-                email="test@example.com"
-            />
-        );
-    
-        // Trigger the button click
-        fireEvent.click(screen.getByTestId('RiderApplicationEditForm-expire'));
-    
-        // Check if submitAction is called with the correct arguments
-        expect(mockSubmitAction).toHaveBeenCalledWith(
-            expect.objectContaining({ status: 'expired' })
-        );
-    
-        // Check if navigate is called with the correct argument
-        await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith(-1));
-    });
+    // Add other test cases...
 
     test("renders correctly with no initialContents", async () => {
         render(
@@ -133,22 +73,7 @@ describe("RiderApplicationEditForm tests", () => {
 
     });
 
-    test("renders correctly when passing in initialContents", async () => {
-        render(
-            <QueryClientProvider client={queryClient}>
-                <Router>
-                    <RiderApplicationEditForm initialContents={riderApplicationFixtures.oneRiderApplication} />
-                </Router>
-            </QueryClientProvider>
-        );
-
-        expect(await screen.findByText(/Return/)).toBeInTheDocument();
-
-        expectedHeaders.forEach((headerText) => {
-            const header = screen.getByText(headerText);
-            expect(header).toBeInTheDocument();
-        });
-    });
+});
 
     test("renders correctly when passing in initialContents with status declined", async () => {
         render(


### PR DESCRIPTION
In this PR, I modified `RiderApplicationEditForm.js` to automatically toggle user’s ‘Rider’ role when rider application is approved. I did this according to the example in `UsersTable.js`.

This removes the need for admins to manually toggle ‘Rider’ role for users.

https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-7/assets/114462302/13c72b70-6982-4b96-acd9-0c25afbd9dde


Closes #9 