### PR TITLE
ride table assign

### DIFF
--- a/frontend/src/fixtures/rideFixtures.js
+++ b/frontend/src/fixtures/rideFixtures.js
@@ -12,7 +12,7 @@ const rideFixtures = {
         "pickupRoom" : "111",
         "course": "CMPSC111",
         "notes": "",
-        "shiftId": "2"
+        "shiftId": 2
       }
     ],
     threeRidesTable:
@@ -30,7 +30,7 @@ const rideFixtures = {
             "pickupRoom": "124",
             "course": "CMPSC64",
             "notes": "N/A",
-            "shiftId": "2"
+            "shiftId": 10
         },
 
         {
@@ -46,7 +46,7 @@ const rideFixtures = {
             "pickupRoom": "125",
             "course": "CMPSC138",
             "notes": "Hi",
-            "shiftId": "100"
+            "shiftId": 0
         },
 
         {
@@ -62,7 +62,7 @@ const rideFixtures = {
             "pickupRoom": "125",
             "course": "CMPSC156",
             "notes": "2 people",   
-            "shiftId": "10"
+            "shiftId": 10
         },
         
     ],
@@ -79,7 +79,7 @@ const rideFixtures = {
             "pickupRoom": "125",
             "course": "CMPSC64",
             "notes": "3rides1",
-            "shiftId": "2"
+            "shiftId": 2
         },
 
         {
@@ -93,7 +93,7 @@ const rideFixtures = {
             "pickupRoom": "125",
             "course": "CMPSC138",
             "notes": "3rides2",
-            "shiftId": "7"
+            "shiftId": 7
         },
 
         {
@@ -107,7 +107,7 @@ const rideFixtures = {
             "pickupRoom": "125",
             "course": "CMPSC156",
             "notes": "3rides3",
-            "shiftId": "3"
+            "shiftId": 3
         },
         
     ]

--- a/frontend/src/main/components/Ride/RideTable.js
+++ b/frontend/src/main/components/Ride/RideTable.js
@@ -184,6 +184,11 @@ export default function RideTable({
         {
             Header: 'Notes',
             accessor: 'notes',
+        },
+        {
+            Header: 'Assigned Status',
+            accessor: 'shiftId',
+            Cell: ({ value }) => (value === 0 ? 'Unassigned' : 'Assigned')
         }
     ];
 

--- a/frontend/src/tests/components/Ride/RideTable.test.js
+++ b/frontend/src/tests/components/Ride/RideTable.test.js
@@ -137,8 +137,8 @@ describe("RideTable tests", () => {
 
     );
 
-    const expectedHeaders = ['id','Day', 'Course #', 'Pick Up Time', 'Drop Off Time', 'Pick Up Building', 'Pick Up Room', 'Drop Off Building', 'Drop Off Room', 'Notes'];
-    const expectedFields = ['id', 'day', 'course', 'startTime', 'endTime', 'pickupBuilding', 'pickupRoom', 'dropoffBuilding','dropoffRoom', 'notes'];
+    const expectedHeaders = ['id','Day', 'Course #', 'Pick Up Time', 'Drop Off Time', 'Pick Up Building', 'Pick Up Room', 'Drop Off Building', 'Drop Off Room', 'Notes', 'Assigned Status'];
+    const expectedFields = ['id', 'day', 'course', 'startTime', 'endTime', 'pickupBuilding', 'pickupRoom', 'dropoffBuilding','dropoffRoom', 'notes', 'shiftId'];
     const testId = "RideTable";
 
     expectedHeaders.forEach((headerText) => {
@@ -150,6 +150,12 @@ describe("RideTable tests", () => {
       const header = getByTestId(`${testId}-cell-row-0-col-${field}`);
       expect(header).toBeInTheDocument();
     });
+
+    const assigned = getByTestId(`${testId}-cell-row-0-col-shiftId`);
+    expect(assigned).toHaveTextContent(/^Assigned$/);
+
+    const unassigned = getByTestId(`${testId}-cell-row-1-col-shiftId`);
+    expect(unassigned).toHaveTextContent(/^Unassigned$/);
 
     expect(getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("2");
     expect(getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("3");


### PR DESCRIPTION
For this feature, I changed RideTable.js to add another column called "assigned" and if the shift id of the ride request changes... the request changes to assigned, and if the shift_id = 0... then it is unassigned. This will help the rider know if their ride was picked up. The shift_id changes when a driver goes into the requests and picks up a shift and changes it. For testing, I had to change the fixtures and test file also. 
<img width="1356" alt="Screenshot 2024-05-22 at 3 46 27 PM" src="https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-7/assets/102608569/06b058e5-c9cb-495e-814d-e90ef443efed">
<img width="1344" alt="Screenshot 2024-05-22 at 3 44 49 PM" src="https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-7/assets/102608569/c6bfb675-5dee-4c64-8f76-40236cbed353">
