### PR TITLE
kk - driver availability bug fix

### DIFF
--- a/frontend/src/main/pages/Drivers/DriverAvailabilityIndexPage.js
+++ b/frontend/src/main/pages/Drivers/DriverAvailabilityIndexPage.js
@@ -14,7 +14,7 @@ export default function DriverAvailabilityIndexPage() {
         useBackend(
             // Stryker disable all : hard to test for query caching
             ["/api/driverAvailability"],
-            { method: "GET", url: "/api/driverAvailability/admin/all" },
+            { method: "GET", url: "/api/driverAvailability" },
             []
             // Stryker restore all 
         );

--- a/frontend/src/tests/pages/Drivers/DriverAvailabilityIndexPage.test.js
+++ b/frontend/src/tests/pages/Drivers/DriverAvailabilityIndexPage.test.js
@@ -45,7 +45,7 @@ describe("DriverAvailabilityIndexPage tests", () => {
 
     test("fetches driverAvailabilities using the correct GET method", async () => {
         setupAdminUser();
-        axiosMock.onGet("/api/driverAvailability/admin/all").reply(config => {
+        axiosMock.onGet("/api/driverAvailability").reply(config => {
             if (config.method === "get") {  // Ensures the method is GET
                 return [200, driverAvailabilityFixtures.threeAvailability];
             }
@@ -76,7 +76,7 @@ describe("DriverAvailabilityIndexPage tests", () => {
         // This variable will help us verify that the correct method was used.
         let wasGetMethodUsed = false;
     
-        axiosMock.onAny("/api/driverAvailability/admin/all").reply(config => {
+        axiosMock.onAny("/api/driverAvailability").reply(config => {
             if (config.method === "get") {  
                 wasGetMethodUsed = true; 
                 return [200, driverAvailabilityFixtures.threeAvailability];


### PR DESCRIPTION
Changed the frontend API calls so that non-admin users can now see driver availabilities with no toasts.

Dokku deployment link: https://gauchoride-koraykondakci-bug.dokku-15.cs.ucsb.edu

<img width="1439" alt="Screenshot 2024-05-22 at 8 06 18 PM" src="https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-7/assets/92008484/ed016992-ccaf-4439-a51a-8665525f3c4f">

Closes #7 