### PR TITLE
kk - driver availability feature

### DIFF
--- a/frontend/src/main/components/Driver/DriverAvailabilityTable.js
+++ b/frontend/src/main/components/Driver/DriverAvailabilityTable.js
@@ -1,5 +1,6 @@
 import React from "react";
 import OurTable, { ButtonColumn } from "main/components/OurTable";
+import { Link } from "react-router-dom";
 
 import { useBackendMutation } from "main/utils/useBackend";
 import { cellToAxiosParamsDelete, onDeleteSuccess } from "main/utils/driverAvailabilityUtils"
@@ -14,10 +15,6 @@ export default function DriverAvailabilityTable({
 
     const editCallback = (cell) => {
         navigate(`/availability/edit/${cell.row.values.id}`)
-    }
-
-    const reviewCallback = (cell) => {
-        navigate(`/admin/availability/review/${cell.row.values.id}`)
     }
 
     // Stryker disable all : hard to test for query caching
@@ -40,6 +37,10 @@ export default function DriverAvailabilityTable({
         {
             Header: 'Driver Id',
             accessor: 'driverId',
+            Cell: ({ value }) => (
+                // Stryker disable next-line all : hard to set up test
+                <Link to={`/driverInfo/${value}`}>{value}</Link>
+              ),
         },
         {
             Header: 'Day',
@@ -65,14 +66,10 @@ export default function DriverAvailabilityTable({
         ButtonColumn("Edit", "primary", editCallback, "DriverAvailabilityTable"),
         ButtonColumn("Delete", "danger", deleteCallback, "DriverAvailabilityTable")
     ];
-
-    const buttonColumnsAdmin = [
-        ...columns,
-        ButtonColumn("Review", "primary", reviewCallback, "DriverAvailabilityTable")
-    ];
+    
     // Stryker restore all 
 
-    const columnsToDisplay = (hasRole(currentUser, "ROLE_ADMIN")) ? buttonColumnsAdmin : (hasRole(currentUser, "ROLE_DRIVER")) ? buttonColumnsDriver : columns;
+    const columnsToDisplay = (hasRole(currentUser, "ROLE_DRIVER")) ? buttonColumnsDriver : columns;
 
     return <OurTable
         data={Availability}

--- a/frontend/src/main/pages/DriverInfoPage.js
+++ b/frontend/src/main/pages/DriverInfoPage.js
@@ -3,8 +3,10 @@ import { useParams } from "react-router-dom";
 import { useBackend } from "main/utils/useBackend";
 import DriverInfo from "main/components/Driver/DriverInfo";
 import { Button } from 'react-bootstrap';
+import { useNavigate } from "react-router-dom";
 
 export default function DriverInfoPage() {
+    const navigate = useNavigate();
     let { id } = useParams();
 
     const { data: info, _error, _status } =
@@ -26,7 +28,7 @@ export default function DriverInfoPage() {
             return (
                 <Button
                     variant="primary"
-                    href="/shift/"
+                    onClick={() => navigate(-1)}
                 >
                     Return
                 </Button>

--- a/frontend/src/main/pages/Drivers/DriverAvailabilityIndexPage.js
+++ b/frontend/src/main/pages/Drivers/DriverAvailabilityIndexPage.js
@@ -14,7 +14,7 @@ export default function DriverAvailabilityIndexPage() {
         useBackend(
             // Stryker disable all : hard to test for query caching
             ["/api/driverAvailability"],
-            { method: "GET", url: "/api/driverAvailability/admin/all" },
+            { method: "GET", url: "/api/driverAvailability" },
             []
             // Stryker restore all 
         );

--- a/frontend/src/tests/components/Driver/DriverAvailabilityTable.test.js
+++ b/frontend/src/tests/components/Driver/DriverAvailabilityTable.test.js
@@ -146,10 +146,6 @@ describe("DriverAvailabilityTable tests", () => {
   
       expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
       expect(screen.getByTestId(`${testId}-cell-row-0-col-driverId`)).toHaveTextContent("4");
-  
-      const reviewButton = screen.getByTestId(`${testId}-cell-row-0-col-Review-button`);
-      expect(reviewButton).toBeInTheDocument();
-      expect(reviewButton).toHaveClass("btn-primary");
     });
 
 
@@ -180,53 +176,5 @@ describe("DriverAvailabilityTable tests", () => {
         expect(screen.queryByText("Delete")).not.toBeInTheDocument();
         expect(screen.queryByText("Edit")).not.toBeInTheDocument();
     });
-      
-      test("Review button triggers navigation", async () => {
-        const currentUser = currentUserFixtures.adminUser;
-      
-        render(
-          <QueryClientProvider client={queryClient}>
-            <MemoryRouter>
-              <DriverAvailabilityTable Availability={driverAvailabilityFixtures.threeAvailability} currentUser={currentUser} />
-            </MemoryRouter>
-          </QueryClientProvider>
-        );
-      
-        // assert - check that the expected content is rendered
-        expect(await screen.findByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
-        const editButton = screen.getByTestId(`${testId}-cell-row-0-col-Review-button`);
-        expect(editButton).toBeInTheDocument();
-      
-        // act - click the edit button
-        fireEvent.click(editButton);
-      
-        // assert - check if the mocked navigate function was called
-        expect(mockedNavigate).toHaveBeenCalledWith('/admin/availability/review/1');
-      });
-      
-  test("Review button navigates to the edit page", async () => {
-    const currentUser = currentUserFixtures.adminUser;
-
-    render(
-      <QueryClientProvider client={queryClient}>
-        <MemoryRouter>
-          <DriverAvailabilityTable Availability={driverAvailabilityFixtures.threeAvailability} currentUser={currentUser} />
-        </MemoryRouter>
-      </QueryClientProvider>
-    );
-
-    // assert - check that the expected content is rendered
-    expect(await screen.findByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
-    expect(screen.getByTestId(`${testId}-cell-row-0-col-driverId`)).toHaveTextContent("4");
-
-    const reviewButton = screen.getByTestId(`${testId}-cell-row-0-col-Review-button`);
-    expect(reviewButton).toBeInTheDocument();
-
-    // act - click the edit button
-    fireEvent.click(reviewButton);
-
-    // assert - check that we navigated to the expected path
-    await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith('/admin/availability/review/1'));
-  });
 
 });

--- a/frontend/src/tests/pages/DriverInfoPage.test.js
+++ b/frontend/src/tests/pages/DriverInfoPage.test.js
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
@@ -100,5 +100,24 @@ describe("DriverInfoPage tests", () => {
             expect(screen.getByText("gName fName, Email: example@gmail.com")).toBeInTheDocument();
         });
 
+    });
+
+    test("renders and clicks return button", async () => {
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <DriverInfoPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => {
+            expect(screen.getByText("Return")).toBeInTheDocument();
+        });
+
+        const returnButton = screen.getByText("Return");
+        fireEvent.click(returnButton);
+       
     });
 });

--- a/frontend/src/tests/pages/Drivers/DriverAvailabilityIndexPage.test.js
+++ b/frontend/src/tests/pages/Drivers/DriverAvailabilityIndexPage.test.js
@@ -45,7 +45,7 @@ describe("DriverAvailabilityIndexPage tests", () => {
 
     test("fetches driverAvailabilities using the correct GET method", async () => {
         setupAdminUser();
-        axiosMock.onGet("/api/driverAvailability/admin/all").reply(config => {
+        axiosMock.onGet("/api/driverAvailability").reply(config => {
             if (config.method === "get") {  // Ensures the method is GET
                 return [200, driverAvailabilityFixtures.threeAvailability];
             }
@@ -76,7 +76,7 @@ describe("DriverAvailabilityIndexPage tests", () => {
         // This variable will help us verify that the correct method was used.
         let wasGetMethodUsed = false;
     
-        axiosMock.onAny("/api/driverAvailability/admin/all").reply(config => {
+        axiosMock.onAny("/api/driverAvailability").reply(config => {
             if (config.method === "get") {  
                 wasGetMethodUsed = true; 
                 return [200, driverAvailabilityFixtures.threeAvailability];


### PR DESCRIPTION
I improved the usability of admin DriverAvailabilityIndexPage so that admins can now click on driver id to see driver's information. I also removed the Review button from this page and modified the Return button on the Driver Info page so that it takes you back to the previous page every time. 

here is what the page looks like (driver id is now a hyperlink and Review button is removed):
<img width="1440" alt="Screenshot 2024-05-25 at 5 15 48 AM" src="https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-7/assets/92008484/d824fefd-66c3-44a5-9021-81f7006124a9">


when you click on driverID, you can view the information page on that driver and the return button takes you back:
<img width="1440" alt="Screenshot 2024-05-25 at 5 10 10 AM" src="https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-7/assets/92008484/7a6bec47-7d06-4d9c-b92c-8564bec8ad1a">

Closes #6  