### PR TITLE
FEATURE: Fixed Form Labels on Driver Availability Form Page

### DIFF
--- a/frontend/src/main/components/Driver/DriverAvailabilityForm.js
+++ b/frontend/src/main/components/Driver/DriverAvailabilityForm.js
@@ -19,7 +19,7 @@ function DriverAvailabilityForm({ initialContents, submitAction, buttonLabel = "
         <Form onSubmit={handleSubmit(submitAction)}>
             {initialContents && (
                 <Form.Group className="mb-3" >
-                    <Form.Label htmlFor="id">id</Form.Label>
+                    <Form.Label htmlFor="id">ID</Form.Label>
                     <Form.Control
                         data-testid={testIdPrefix + "-id"}
                         id="id"
@@ -31,14 +31,14 @@ function DriverAvailabilityForm({ initialContents, submitAction, buttonLabel = "
                 </Form.Group>
             )}
             <Form.Group className="mb-3" >
-                <Form.Label htmlFor="driverId">driverId</Form.Label>
+                <Form.Label htmlFor="driverId">Driver ID</Form.Label>
                 <Form.Control
                     data-testid={testIdPrefix + "-driverId"}
                     id="driverId"
                     type="text"
                     isInvalid={Boolean(errors.driverId)}
                     {...register("driverId", {
-                        required: "driverId is required.",
+                        required: "Driver ID is required.",
                     })}
                 />
                 <Form.Control.Feedback type="invalid">
@@ -47,14 +47,14 @@ function DriverAvailabilityForm({ initialContents, submitAction, buttonLabel = "
             </Form.Group>
 
             <Form.Group className="mb-3" >
-                <Form.Label htmlFor="day">day</Form.Label>
+                <Form.Label htmlFor="day">Day</Form.Label>
                 <Form.Control
                     data-testid={testIdPrefix + "-day"}
                     id="day"
                     type="text"
                     isInvalid={Boolean(errors.day)}
                     {...register("day", {
-                        required: "day is required."
+                        required: "Day is required."
                     })}
                 />
                 <Form.Control.Feedback type="invalid">
@@ -63,14 +63,14 @@ function DriverAvailabilityForm({ initialContents, submitAction, buttonLabel = "
             </Form.Group>
 
             <Form.Group className="mb-3" >
-                <Form.Label htmlFor="startTime">startTime</Form.Label>
+                <Form.Label htmlFor="startTime">Start Time</Form.Label>
                 <Form.Control
                     data-testid={testIdPrefix + "-startTime"}
                     id="startTime"
                     type="text"
                     isInvalid={Boolean(errors.startTime)}
                     {...register("startTime", {
-                        required: "startTime is required."
+                        required: "Start Time is required."
                     })}
                 />
                 <Form.Control.Feedback type="invalid">
@@ -79,14 +79,14 @@ function DriverAvailabilityForm({ initialContents, submitAction, buttonLabel = "
             </Form.Group>
 
             <Form.Group className="mb-3" >
-                <Form.Label htmlFor="endTime">endTime</Form.Label>
+                <Form.Label htmlFor="endTime">End Time</Form.Label>
                 <Form.Control
                     data-testid={testIdPrefix + "-endTime"}
                     id="endTime"
                     type="text"
                     isInvalid={Boolean(errors.endTime)}
                     {...register("endTime", {
-                        required: "endTime is required."
+                        required: "End Time is required."
                     })}
                 />
                 <Form.Control.Feedback type="invalid">
@@ -95,14 +95,14 @@ function DriverAvailabilityForm({ initialContents, submitAction, buttonLabel = "
             </Form.Group>
 
             <Form.Group className="mb-3" >
-                <Form.Label htmlFor="notes">notes</Form.Label>
+                <Form.Label htmlFor="notes">Notes</Form.Label>
                 <Form.Control
                     data-testid={testIdPrefix + "-notes"}
                     id="notes"
                     type="text"
                     isInvalid={Boolean(errors.notes)}
                     {...register("notes", {
-                        required: "notes is required."
+                        required: "Notes are required."
                     })}
                 />
                 <Form.Control.Feedback type="invalid">
@@ -125,7 +125,6 @@ function DriverAvailabilityForm({ initialContents, submitAction, buttonLabel = "
             </Button>
 
         </Form>
-
     )
 }
 

--- a/frontend/src/tests/components/Driver/DriverAvailabilityForm.test.js
+++ b/frontend/src/tests/components/Driver/DriverAvailabilityForm.test.js
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { BrowserRouter as Router } from "react-router-dom";
 
-import DriverAvailabilityForm from "main/components/Driver/DriverAvailabilityForm"
+import DriverAvailabilityForm from "main/components/Driver/DriverAvailabilityForm";
 import { driverAvailabilityFixtures } from 'fixtures/driverAvailabilityFixtures';
 
 import { QueryClient, QueryClientProvider } from "react-query";
@@ -16,7 +16,7 @@ jest.mock('react-router-dom', () => ({
 describe("DriverAvailabilityForm tests", () => {
     const queryClient = new QueryClient();
 
-    const expectedHeaders = ["driverId", "day", "startTime", "endTime", "notes"];
+    const expectedHeaders = ["Driver ID", "Day", "Start Time", "End Time", "Notes"];
     const testId = "DriverAvailabilityForm";
 
     test("renders correctly with no initialContents", async () => {
@@ -34,7 +34,6 @@ describe("DriverAvailabilityForm tests", () => {
             const header = screen.getByText(headerText);
             expect(header).toBeInTheDocument();
         });
-
     });
 
     test("renders correctly when passing in initialContents", async () => {
@@ -54,24 +53,23 @@ describe("DriverAvailabilityForm tests", () => {
         });
 
         expect(await screen.findByTestId(`${testId}-id`)).toBeInTheDocument();
-        expect(screen.getByText(`id`)).toBeInTheDocument();
+        expect(screen.getByText(`ID`)).toBeInTheDocument();
 
         expect(await screen.findByTestId(`${testId}-driverId`)).toBeInTheDocument();
-        expect(screen.getByText(`driverId`)).toBeInTheDocument();
+        expect(screen.getByText(`Driver ID`)).toBeInTheDocument();
 
         expect(await screen.findByTestId(`${testId}-day`)).toBeInTheDocument();
-        expect(screen.getByText(`day`)).toBeInTheDocument();
+        expect(screen.getByText(`Day`)).toBeInTheDocument();
 
         expect(await screen.findByTestId(`${testId}-startTime`)).toBeInTheDocument();
-        expect(screen.getByText(`startTime`)).toBeInTheDocument();
+        expect(screen.getByText(`Start Time`)).toBeInTheDocument();
 
         expect(await screen.findByTestId(`${testId}-endTime`)).toBeInTheDocument();
-        expect(screen.getByText(`endTime`)).toBeInTheDocument();
+        expect(screen.getByText(`End Time`)).toBeInTheDocument();
 
         expect(await screen.findByTestId(`${testId}-notes`)).toBeInTheDocument();
-        expect(screen.getByText(`notes`)).toBeInTheDocument();
+        expect(screen.getByText(`Notes`)).toBeInTheDocument();
     });
-
 
     test("that navigate(-1) is called when Cancel is clicked", async () => {
         render(
@@ -102,21 +100,18 @@ describe("DriverAvailabilityForm tests", () => {
         const submitButton = screen.getByText(/Create/);
         fireEvent.click(submitButton);
 
-        await screen.findByText(/driverId is required./);
-        expect(screen.getByText(/day is required./)).toBeInTheDocument();
-        expect(screen.getByText(/startTime is required./)).toBeInTheDocument();
-        expect(screen.getByText(/endTime is required./)).toBeInTheDocument();
-        expect(screen.getByText(/notes is required./)).toBeInTheDocument();
-
+        await screen.findByText(/Driver ID is required./);
+        expect(screen.getByText(/Day is required./)).toBeInTheDocument();
+        expect(screen.getByText(/Start Time is required./)).toBeInTheDocument();
+        expect(screen.getByText(/End Time is required./)).toBeInTheDocument();
+        expect(screen.getByText(/Notes are required./)).toBeInTheDocument();
     });
 
-    test("No Error messsages on good input", async () => {
-
+    test("No Error messages on good input", async () => {
         const mockSubmitAction = jest.fn();
 
-
         render(
-            <Router  >
+            <Router>
                 <DriverAvailabilityForm submitAction={mockSubmitAction} />
             </Router>
         );
@@ -138,13 +133,10 @@ describe("DriverAvailabilityForm tests", () => {
 
         await waitFor(() => expect(mockSubmitAction).toHaveBeenCalled());
 
-        expect(screen.queryByText(/driverId is required./)).not.toBeInTheDocument();
-        expect(screen.queryByText(/day is required./)).not.toBeInTheDocument();
-        expect(screen.queryByText(/startTime is required./)).not.toBeInTheDocument();
-        expect(screen.queryByText(/endTime is required./)).not.toBeInTheDocument();
-        expect(screen.queryByText(/notes is required./)).not.toBeInTheDocument();
-
-
+        expect(screen.queryByText(/Driver ID is required./)).not.toBeInTheDocument();
+        expect(screen.queryByText(/Day is required./)).not.toBeInTheDocument();
+        expect(screen.queryByText(/Start Time is required./)).not.toBeInTheDocument();
+        expect(screen.queryByText(/End Time is required./)).not.toBeInTheDocument();
+        expect(screen.queryByText(/Notes are required./)).not.toBeInTheDocument();
     });
-
 });

--- a/frontend/src/tests/pages/Drivers/DriverAvailabilityCreatePage.test.js
+++ b/frontend/src/tests/pages/Drivers/DriverAvailabilityCreatePage.test.js
@@ -82,21 +82,21 @@ describe("DriverAvailabilityCreatePage tests", () => {
         )
 
 
-        const driverIdInput = screen.getByLabelText("driverId")
+        const driverIdInput = screen.getByLabelText("Driver ID")
         await waitFor(() => {
             expect(driverIdInput).toBeInTheDocument();
         });
 
-        const dayInput = screen.getByLabelText("day");
+        const dayInput = screen.getByLabelText("Day");
         expect(dayInput).toBeInTheDocument();
 
-        const startTimeInput = screen.getByLabelText("startTime");
+        const startTimeInput = screen.getByLabelText("Start Time");
         expect(startTimeInput).toBeInTheDocument();
 
-        const endTimeInput = screen.getByLabelText("endTime");
+        const endTimeInput = screen.getByLabelText("End Time");
         expect(endTimeInput).toBeInTheDocument();
 
-        const notesInput = screen.getByLabelText("notes");
+        const notesInput = screen.getByLabelText("Notes");
         expect(notesInput).toBeInTheDocument();
 
         // Simulating filling out the form


### PR DESCRIPTION
In this PR, I capitalized and added spaces to the form labels on the Driver Availability Form. I also properly formatted the error messages. These changes were implemented in `DriverAvailabilityForm.js`. I also modified test cases to conform to the new form labels.

My changes elevate this page's professionalism to the level of other form pages in the app.

Closes #51

Previous Driver Availability form labels:
![image](https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-7/assets/114462302/11714e93-edf6-4b06-9886-578e25581293)

Updated Driver Availability form labels:
<img width="1257" alt="image" src="https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-7/assets/114462302/68719e47-5a1f-4590-a8ea-3dad823f78cd">

Modified error messages:
<img width="1280" alt="image" src="https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-7/assets/114462302/6add7ff2-6594-4087-b727-1d4f1b7a1586">

