### PR TITLE
Kate commit info feature

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,9 @@ RUN apk add curl
 RUN apk add bash
 RUN apk add maven
 RUN apk add --no-cache libstdc++
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | bash
 # added line below
 RUN apk add git
-RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | bash
 ENV NVM_DIR=/root/.nvm
 RUN . "$NVM_DIR/nvm.sh" && nvm install ${NODE_VERSION}
 RUN . "$NVM_DIR/nvm.sh" && nvm use v${NODE_VERSION}

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,6 @@ RUN apk add bash
 RUN apk add maven
 RUN apk add --no-cache libstdc++
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | bash
-# added line below
 RUN apk add git
 ENV NVM_DIR=/root/.nvm
 RUN . "$NVM_DIR/nvm.sh" && nvm install ${NODE_VERSION}
@@ -17,23 +16,6 @@ RUN . "$NVM_DIR/nvm.sh" && nvm use v${NODE_VERSION}
 RUN . "$NVM_DIR/nvm.sh" && nvm alias default v${NODE_VERSION}
 ENV PATH="/root/.nvm/versions/node/v${NODE_VERSION}/bin/:${PATH}"
 
-# commented out for git commit info
-
-#RUN node --version
-#RUN npm --version
-
-# This approach (copying entire directory including git info) 
-# relies on the dokku setting:
-#   dokku git:set appname keep-git-dir true
-
-# commented out for git commit info
-
-#COPY frontend /home/app/frontend
-#COPY src /home/app/src
-#COPY lombok.config /home/app
-#COPY pom.xml /home/app
-
-# added line below
 COPY . /home/app
 
 ENV PRODUCTION=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN apk add curl
 RUN apk add bash
 RUN apk add maven
 RUN apk add --no-cache libstdc++
+# added line below
 RUN apk add git
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | bash
 ENV NVM_DIR=/root/.nvm
@@ -16,6 +17,8 @@ RUN . "$NVM_DIR/nvm.sh" && nvm use v${NODE_VERSION}
 RUN . "$NVM_DIR/nvm.sh" && nvm alias default v${NODE_VERSION}
 ENV PATH="/root/.nvm/versions/node/v${NODE_VERSION}/bin/:${PATH}"
 
+# commented out for git commit info
+
 #RUN node --version
 #RUN npm --version
 
@@ -23,11 +26,14 @@ ENV PATH="/root/.nvm/versions/node/v${NODE_VERSION}/bin/:${PATH}"
 # relies on the dokku setting:
 #   dokku git:set appname keep-git-dir true
 
+# commented out for git commit info
 
 #COPY frontend /home/app/frontend
 #COPY src /home/app/src
 #COPY lombok.config /home/app
 #COPY pom.xml /home/app
+
+# added line below
 COPY . /home/app
 
 ENV PRODUCTION=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN apk add curl
 RUN apk add bash
 RUN apk add maven
 RUN apk add --no-cache libstdc++
+RUN apk add git
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | bash
 ENV NVM_DIR=/root/.nvm
 RUN . "$NVM_DIR/nvm.sh" && nvm install ${NODE_VERSION}
@@ -15,13 +16,19 @@ RUN . "$NVM_DIR/nvm.sh" && nvm use v${NODE_VERSION}
 RUN . "$NVM_DIR/nvm.sh" && nvm alias default v${NODE_VERSION}
 ENV PATH="/root/.nvm/versions/node/v${NODE_VERSION}/bin/:${PATH}"
 
-RUN node --version
-RUN npm --version
+#RUN node --version
+#RUN npm --version
 
-COPY frontend /home/app/frontend
-COPY src /home/app/src
-COPY lombok.config /home/app
-COPY pom.xml /home/app
+# This approach (copying entire directory including git info) 
+# relies on the dokku setting:
+#   dokku git:set appname keep-git-dir true
+
+
+#COPY frontend /home/app/frontend
+#COPY src /home/app/src
+#COPY lombok.config /home/app
+#COPY pom.xml /home/app
+COPY . /home/app
 
 ENV PRODUCTION=true
 RUN mvn -B -DskipTests -Pproduction -f /home/app/pom.xml clean package

--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,30 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>io.github.git-commit-id</groupId>
+                <artifactId>git-commit-id-maven-plugin</artifactId>
+                <version>8.0.2</version>
+                <executions>
+                    <execution>
+                        <id>get-the-git-infos</id>
+                        <goals>
+                            <goal>revision</goal>
+                        </goals>
+                        <phase>initialize</phase>
+                    </execution>
+                </executions>
+                 <configuration>
+                        <includeOnlyProperties>
+                            <includeOnlyProperty>^git.build.(time|version)$</includeOnlyProperty>
+                            <includeOnlyProperty>^git.commit.id.(abbrev|full)$</includeOnlyProperty>
+                            <includeOnlyProperty>^git.commit.message.short$</includeOnlyProperty>
+                    </includeOnlyProperties>
+                    <generateGitPropertiesFile>true</generateGitPropertiesFile>
+                    <generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties</generateGitPropertiesFilename>
+                    <commitIdGenerationMode>full</commitIdGenerationMode>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>
@@ -278,33 +302,6 @@
                             </execution>
                         </executions>
                     </plugin>
-
-                    <!--Added for github commit info-->
-
-                    <plugin>
-                        <groupId>io.github.git-commit-id</groupId>
-                        <artifactId>git-commit-id-maven-plugin</artifactId>
-                        <version>8.0.2</version>
-                        <executions>
-                            <execution>
-                                <id>get-the-git-infos</id>
-                                <goals>
-                                    <goal>revision</goal>
-                                </goals>
-                                <phase>initialize</phase>
-                            </execution>
-                        </executions>
-                        <configuration>
-                            <generateGitPropertiesFile>true</generateGitPropertiesFile>
-                            
-                            <generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties</generateGitPropertiesFilename>
-                            <commitIdGenerationMode>full</commitIdGenerationMode>
-                        </configuration>
-                    </plugin>
-
-                    <!--end of things added-->
-
-
                 </plugins>
             </build>
         </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -278,6 +278,31 @@
                             </execution>
                         </executions>
                     </plugin>
+
+                    <!--Added for github commit info-->
+
+                    <plugin>
+                        <groupId>io.github.git-commit-id</groupId>
+                        <artifactId>git-commit-id-maven-plugin</artifactId>
+                        <version>8.0.2</version>
+                        <executions>
+                            <execution>
+                                <id>get-the-git-infos</id>
+                                <goals>
+                                    <goal>revision</goal>
+                                </goals>
+                                <phase>initialize</phase>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <generateGitPropertiesFile>true</generateGitPropertiesFile>
+                            
+                            <generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties</generateGitPropertiesFilename>
+                            <commitIdGenerationMode>full</commitIdGenerationMode>
+                        </configuration>
+                    </plugin>
+
+
                 </plugins>
             </build>
         </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -302,6 +302,8 @@
                         </configuration>
                     </plugin>
 
+                    <!--end of things added-->
+
 
                 </plugins>
             </build>

--- a/src/main/java/edu/ucsb/cs156/gauchoride/models/SystemInfo.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/models/SystemInfo.java
@@ -6,7 +6,6 @@ import lombok.NoArgsConstructor;
 import lombok.Builder;
 import lombok.AccessLevel;
 
-
 @Data
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -14,4 +13,9 @@ import lombok.AccessLevel;
 public class SystemInfo {
   private Boolean springH2ConsoleEnabled;
   private Boolean showSwaggerUILink;
+
+  private String sourceRepo; // user configured URL of the source repository for footer
+  private String commitMessage;
+  private String commitId;
+  private String githubUrl; // URL to the commit in the source repository
 }

--- a/src/main/java/edu/ucsb/cs156/gauchoride/models/SystemInfo.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/models/SystemInfo.java
@@ -15,6 +15,8 @@ public class SystemInfo {
   private Boolean showSwaggerUILink;
 
   // added for git commit info
+  private String startQtrYYYYQ;
+  private String endQtrYYYYQ;
   private String sourceRepo; // user configured URL of the source repository for footer
   private String commitMessage;
   private String commitId;

--- a/src/main/java/edu/ucsb/cs156/gauchoride/models/SystemInfo.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/models/SystemInfo.java
@@ -14,6 +14,7 @@ public class SystemInfo {
   private Boolean springH2ConsoleEnabled;
   private Boolean showSwaggerUILink;
 
+  // added for git commit info
   private String sourceRepo; // user configured URL of the source repository for footer
   private String commitMessage;
   private String commitId;

--- a/src/main/java/edu/ucsb/cs156/gauchoride/services/SystemInfoServiceImpl.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/services/SystemInfoServiceImpl.java
@@ -36,10 +36,14 @@ public class SystemInfoServiceImpl extends SystemInfoService {
     return commit != null && repo != null ? repo + "/commit/" + commit : null;
   }
 
+  // end of new things added
+
   public SystemInfo getSystemInfo() {
     SystemInfo si = SystemInfo.builder()
         .springH2ConsoleEnabled(this.springH2ConsoleEnabled)
         .showSwaggerUILink(this.showSwaggerUILink)
+
+        // added for git commit info feature
         .sourceRepo(this.sourceRepo)
         .commitMessage(this.commitMessage)
         .commitId(this.commitId)

--- a/src/main/java/edu/ucsb/cs156/gauchoride/services/SystemInfoServiceImpl.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/services/SystemInfoServiceImpl.java
@@ -1,6 +1,5 @@
 package edu.ucsb.cs156.gauchoride.services;
 
-
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -15,20 +14,39 @@ import edu.ucsb.cs156.gauchoride.models.SystemInfo;
 @Service("systemInfo")
 @ConfigurationProperties
 public class SystemInfoServiceImpl extends SystemInfoService {
-  
+
   @Value("${spring.h2.console.enabled:false}")
   private boolean springH2ConsoleEnabled;
 
   @Value("${app.showSwaggerUILink:false}")
   private boolean showSwaggerUILink;
 
+  // adding values for github commit information
+
+  @Value("${app.sourceRepo:https://github.com/ucsb-cs156/proj-courses}")
+  private String sourceRepo;
+
+  @Value("${git.commit.message.short:unknown}")
+  private String commitMessage;
+
+  @Value("${git.commit.id.abbrev:unknown}")
+  private String commitId;
+
+  public static String githubUrl(String repo, String commit) {
+    return commit != null && repo != null ? repo + "/commit/" + commit : null;
+  }
+
   public SystemInfo getSystemInfo() {
     SystemInfo si = SystemInfo.builder()
-    .springH2ConsoleEnabled(this.springH2ConsoleEnabled)
-    .showSwaggerUILink(this.showSwaggerUILink)
-    .build();
-  log.info("getSystemInfo returns {}",si);
-  return si;
+        .springH2ConsoleEnabled(this.springH2ConsoleEnabled)
+        .showSwaggerUILink(this.showSwaggerUILink)
+        .sourceRepo(this.sourceRepo)
+        .commitMessage(this.commitMessage)
+        .commitId(this.commitId)
+        .githubUrl(githubUrl(this.sourceRepo, this.commitId))
+        .build();
+    log.info("getSystemInfo returns {}", si);
+    return si;
   }
 
 }

--- a/src/main/java/edu/ucsb/cs156/gauchoride/services/SystemInfoServiceImpl.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/services/SystemInfoServiceImpl.java
@@ -32,7 +32,7 @@ public class SystemInfoServiceImpl extends SystemInfoService {
   @Value("${app.endQtrYYYYQ:20222}")
   private String endQtrYYYYQ;
 
-  @Value("${app.sourceRepo:https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-7}")
+  @Value("${app.sourceRepo:https://github.com/ucsb-cs156/proj-gauchoride}")
   private String sourceRepo;
 
   @Value("${git.commit.message.short:unknown}")

--- a/src/main/java/edu/ucsb/cs156/gauchoride/services/SystemInfoServiceImpl.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/services/SystemInfoServiceImpl.java
@@ -3,6 +3,8 @@ package edu.ucsb.cs156.gauchoride.services;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.context.annotation.PropertySources;
 import org.springframework.stereotype.Service;
 
 import edu.ucsb.cs156.gauchoride.models.SystemInfo;
@@ -12,6 +14,7 @@ import edu.ucsb.cs156.gauchoride.models.SystemInfo;
 
 @Slf4j
 @Service("systemInfo")
+@PropertySources(@PropertySource("classpath:git.properties"))
 @ConfigurationProperties
 public class SystemInfoServiceImpl extends SystemInfoService {
 
@@ -23,7 +26,13 @@ public class SystemInfoServiceImpl extends SystemInfoService {
 
   // adding values for github commit information
 
-  @Value("${app.sourceRepo:https://github.com/ucsb-cs156/proj-courses}")
+  @Value("${app.startQtrYYYYQ:20221}")
+  private String startQtrYYYYQ;
+
+  @Value("${app.endQtrYYYYQ:20222}")
+  private String endQtrYYYYQ;
+
+  @Value("${app.sourceRepo:https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-7}")
   private String sourceRepo;
 
   @Value("${git.commit.message.short:unknown}")
@@ -44,6 +53,8 @@ public class SystemInfoServiceImpl extends SystemInfoService {
         .showSwaggerUILink(this.showSwaggerUILink)
 
         // added for git commit info feature
+        .startQtrYYYYQ(this.startQtrYYYYQ)
+        .endQtrYYYYQ(this.endQtrYYYYQ)
         .sourceRepo(this.sourceRepo)
         .commitMessage(this.commitMessage)
         .commitId(this.commitId)

--- a/src/test/java/edu/ucsb/cs156/gauchoride/services/SystemInfoServiceImplTests.java
+++ b/src/test/java/edu/ucsb/cs156/gauchoride/services/SystemInfoServiceImplTests.java
@@ -47,8 +47,8 @@ class SystemInfoServiceImplTests {
   void test_githubUrl() {
     assertEquals(
         SystemInfoServiceImpl.githubUrl(
-            "https://github.com/ucsb-cs156/proj-courses", "abcdef12345"),
-        "https://github.com/ucsb-cs156/proj-courses/commit/abcdef12345");
+            "https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-7", "abcdef12345"),
+        "https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-7/commit/abcdef12345");
     assertNull(SystemInfoServiceImpl.githubUrl(null, null));
     assertNull(SystemInfoServiceImpl.githubUrl("x", null));
     assertNull(SystemInfoServiceImpl.githubUrl(null, "x"));

--- a/src/test/java/edu/ucsb/cs156/gauchoride/services/SystemInfoServiceImplTests.java
+++ b/src/test/java/edu/ucsb/cs156/gauchoride/services/SystemInfoServiceImplTests.java
@@ -2,6 +2,8 @@ package edu.ucsb.cs156.gauchoride.services;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -20,12 +22,11 @@ import edu.ucsb.cs156.gauchoride.services.SystemInfoServiceImpl;
 // The unit under test relies on property values
 // For hints on testing, see: https://www.baeldung.com/spring-boot-testing-configurationproperties
 
-
 @ExtendWith(SpringExtension.class)
 @EnableConfigurationProperties(value = SystemInfoServiceImpl.class)
 @TestPropertySource("classpath:application-development.properties")
-class SystemInfoServiceImplTests  {
-  
+class SystemInfoServiceImplTests {
+
   @Autowired
   private SystemInfoService systemInfoService;
 
@@ -34,6 +35,20 @@ class SystemInfoServiceImplTests  {
     SystemInfo si = systemInfoService.getSystemInfo();
     assertTrue(si.getSpringH2ConsoleEnabled());
     assertTrue(si.getShowSwaggerUILink());
+    assertTrue(si.getGithubUrl().startsWith(si.getSourceRepo()));
+    assertTrue(si.getGithubUrl().endsWith(si.getCommitId()));
+    assertTrue(si.getGithubUrl().contains("/commit/"));
+  }
+
+  @Test
+  void test_githubUrl() {
+    assertEquals(
+        SystemInfoServiceImpl.githubUrl(
+            "https://github.com/ucsb-cs156/proj-courses", "abcdef12345"),
+        "https://github.com/ucsb-cs156/proj-courses/commit/abcdef12345");
+    assertNull(SystemInfoServiceImpl.githubUrl(null, null));
+    assertNull(SystemInfoServiceImpl.githubUrl("x", null));
+    assertNull(SystemInfoServiceImpl.githubUrl(null, "x"));
   }
 
 }

--- a/src/test/java/edu/ucsb/cs156/gauchoride/services/SystemInfoServiceImplTests.java
+++ b/src/test/java/edu/ucsb/cs156/gauchoride/services/SystemInfoServiceImplTests.java
@@ -35,11 +35,14 @@ class SystemInfoServiceImplTests {
     SystemInfo si = systemInfoService.getSystemInfo();
     assertTrue(si.getSpringH2ConsoleEnabled());
     assertTrue(si.getShowSwaggerUILink());
+
+    // added for git commit info feature
     assertTrue(si.getGithubUrl().startsWith(si.getSourceRepo()));
     assertTrue(si.getGithubUrl().endsWith(si.getCommitId()));
     assertTrue(si.getGithubUrl().contains("/commit/"));
   }
 
+  // added test for git commit info feature
   @Test
   void test_githubUrl() {
     assertEquals(


### PR DESCRIPTION
[Link to dokku deployment](https://gauchoride-katelarrick-dev.dokku-15.cs.ucsb.edu/)

After doing these three dokku commands:
dokku git:set appname keep-git-dir true
dokku config:set appname  SOURCE_REPO=https://ucsb-cs156-s24/proj-gauchoride-s24-5pm-7
dokku ps:rebuild appname

You should then be able to see the commit info about the most recent Github commit deployed to that deployment by adding /api/systemInfo to the end of the URL, as in https://gauchoride-katelarrick-dev.dokku-15.cs.ucsb.edu/api/systemInfo

Note: for this PR, the commit info is only visible to admin users who are logged in

Localhost example:
<img width="731" alt="Screenshot 2024-05-28 at 5 03 40 PM" src="https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-7/assets/114554584/b7864976-0280-4eb7-af1b-def14864b409">

Dokku example:
<img width="739" alt="Screenshot 2024-05-29 at 3 33 53 PM" src="https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-7/assets/114554584/a19a561d-cb71-41f7-b890-a838f6b2a049">

Closes #13 
