### PR TITLE
kk - sort user table by id

### DIFF
--- a/frontend/src/fixtures/usersFixtures.js
+++ b/frontend/src/fixtures/usersFixtures.js
@@ -1,7 +1,7 @@
 const usersFixtures = {
     threeUsers: [
         {
-            "id": 1,
+            "id": 2,
             "email": "phtcon@ucsb.edu",
             "googleSub": "115856948234298493496",
             "pictureUrl": "https://lh3.googleusercontent.com/-bQynVrzVIrU/AAAAAAAAAAI/AAAAAAAAAAA/AMZuucmkGuVsELD1ZeV5iDUAUfe6_K-p8w/s96-c/photo.jpg",
@@ -16,7 +16,7 @@ const usersFixtures = {
             "rider": false
         },
         {
-            "id": 2,
+            "id": 3,
             "email": "pconrad.cis@gmail.com",
             "googleSub": "102656447703889917227",
             "pictureUrl": "https://lh3.googleusercontent.com/a-/AOh14GhpDBUt8eCEqiRT45hrFbcimsX_h1ONn0dc3HV8Bp8=s96-c",
@@ -31,7 +31,7 @@ const usersFixtures = {
             "rider": false
         },
         {
-            "id": 3,
+            "id": 1,
             "email": "craig.zzyzx@example.org",
             "googleSub": "123456789012345678901",
             "pictureUrl": "https://lh3.googleusercontent.com/a-/AOh14GhpDBUt8eCEqiRT45hrFbcimsX_h1ONn0dc3HV8Bp8=s96-c",

--- a/frontend/src/main/components/Users/UsersTable.js
+++ b/frontend/src/main/components/Users/UsersTable.js
@@ -111,9 +111,12 @@ export default function UsersTable({ users}) {
     ]
 
     //const columnsToDisplay = showButtons ? buttonColumn : columns;
+    const sortedById = (users) => {
+        return [...users].sort((a, b) => a.id - b.id);
+    };
 
     return <OurTable
-        data={users}
+        data={sortedById(users)}
         columns={buttonColumn}
         testid={"UsersTable"}
     />;

--- a/frontend/src/main/components/Users/UsersTable.js
+++ b/frontend/src/main/components/Users/UsersTable.js
@@ -110,7 +110,6 @@ export default function UsersTable({ users}) {
         ButtonColumn("Toggle Rider", "danger", toggleRiderCallback, "UsersTable")
     ]
 
-    //const columnsToDisplay = showButtons ? buttonColumn : columns;
     const sortedById = (users) => {
         return [...users].sort((a, b) => a.id - b.id);
     };

--- a/frontend/src/tests/components/Users/UsersTable.test.js
+++ b/frontend/src/tests/components/Users/UsersTable.test.js
@@ -45,14 +45,14 @@ describe("UserTable tests", () => {
         });
 
         expect(getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
-        expect(getByTestId(`${testId}-cell-row-0-col-admin`)).toHaveTextContent("true");
+        expect(getByTestId(`${testId}-cell-row-0-col-admin`)).toHaveTextContent("false");
         expect(getByTestId(`${testId}-cell-row-0-col-driver`)).toHaveTextContent("false");
-        expect(getByTestId(`${testId}-cell-row-0-col-rider`)).toHaveTextContent("false");
+        expect(getByTestId(`${testId}-cell-row-0-col-rider`)).toHaveTextContent("true");
         expect(getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
-        expect(getByTestId(`${testId}-cell-row-1-col-admin`)).toHaveTextContent("false");
-        expect(getByTestId(`${testId}-cell-row-1-col-driver`)).toHaveTextContent("true");
+        expect(getByTestId(`${testId}-cell-row-1-col-admin`)).toHaveTextContent("true");
+        expect(getByTestId(`${testId}-cell-row-1-col-driver`)).toHaveTextContent("false");
         expect(getByTestId(`${testId}-cell-row-1-col-rider`)).toHaveTextContent("false");
-        expect(getByTestId(`${testId}-cell-row-2-col-rider`)).toHaveTextContent("true");
+        expect(getByTestId(`${testId}-cell-row-2-col-rider`)).toHaveTextContent("false");
       });
 });
 


### PR DESCRIPTION
I added a simple algorithm that sorts the users table by their id's so that the table stays consistent when a property of a user is toggled. I changed the id's in the users fixture and adjusted the users table tests to ensure that the table displays users in the expected order.


Here's the current users table and you can see that the users are sorted by id's in increasing order:
<img width="1440" alt="Screenshot 2024-05-29 at 5 47 53 PM" src="https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-7/assets/92008484/dadfd26a-374c-4b1e-b010-e46abafffd04">

Closes #15 